### PR TITLE
Added a new SizedBufferPool + README/godoc changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ bpool provides the following pool types:
   [bytes.Buffers](http://golang.org/pkg/bytes/#Buffer).
 * [bpool.BytePool](https://godoc.org/github.com/oxtoacart/bpool#BytePool) which
   provides a fixed-size pool of `[]byte` slices with a pre-set width (length).
+* [bpool.SizedBufferPool](https://godoc.org/github.com/oxtoacart/bpool#SizedBufferPool), 
+  which is an alternative to `bpool.BufferPool` that pre-sizes the capacity of
+  buffers issued from the pool and discards buffers that have grown too large
+  upon return.
 
 A common use case for this package is to use buffers to execute HTML templates
 against (via ExecuteTemplate) or encode JSON into (via json.NewEncoder). This

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # bpool [![GoDoc](https://godoc.org/github.com/oxtoacart/bpool?status.png)](https://godoc.org/github.com/oxtoacart/bpool)
 
-Package bpool implements leaky pools of byte arrays and Buffers as bounded channels. It is based on the leaky buffer example from the Effective Go documentation: http://golang.org/doc/effective_go.html#leaky_buffer
+Package bpool implements leaky pools of byte arrays and Buffers as bounded channels. 
+It is based on the leaky buffer example from the Effective Go documentation: http://golang.org/doc/effective_go.html#leaky_buffer
+
+bpool provides the following pool types:
+
+* [bpool.BufferPool](https://godoc.org/github.com/oxtoacart/bpool#BufferPool)
+  which provides a fixed-size pool of
+  [bytes.Buffers](http://golang.org/pkg/bytes/#Buffer).
+* [bpool.BytePool](https://godoc.org/github.com/oxtoacart/bpool#BytePool) which
+  provides a fixed-size pool of `[]byte` slices with a pre-set width (length).
+
+A common use case for this package is to use buffers to execute HTML templates
+against (via ExecuteTemplate) or encode JSON into (via json.NewEncoder). This
+allows you to catch any rendering or marshalling errors prior to writing to a
+`http.ResponseWriter`, which helps to avoid writing incomplete or malformed data
+to the response.
 
 ## Install
 
@@ -11,6 +26,10 @@ Package bpool implements leaky pools of byte arrays and Buffers as bounded chann
 See [godoc.org](http://godoc.org/github.com/oxtoacart/bpool) or use `godoc github.com/oxtoacart/bpool`
 
 ## Example
+
+Here's a quick example for using `bpool.BufferPool`. We create a pool of the
+desired size, call the `Get()` method to obtain a buffer for use, and call
+`Put(buf)` to return the buffer to the pool.
 
 ```go
 
@@ -31,7 +50,12 @@ func someFunction() error {
      ...
      // Return the buffer to the pool
      bufpool.Put(buf)
-     
+
      return nil
 }
 ```
+
+## License
+
+Apache 2.0 Licensed. See the LICENSE file for details.
+

--- a/bufferpool.go
+++ b/bufferpool.go
@@ -4,27 +4,21 @@ import (
 	"bytes"
 )
 
-/*
-BufferPool implements a pool of bytes.Buffers in the form of a bounded
-channel.
-*/
+// BufferPool implements a pool of bytes.Buffers in the form of a bounded
+// channel.
 type BufferPool struct {
 	c chan *bytes.Buffer
 }
 
-/*
-NewBufferPool creates a new BufferPool bounded to the given size.
-*/
+// NewBufferPool creates a new BufferPool bounded to the given size.
 func NewBufferPool(size int) (bp *BufferPool) {
 	return &BufferPool{
 		c: make(chan *bytes.Buffer, size),
 	}
 }
 
-/*
-Get gets a Buffer from the BufferPool, or creates a new one if none are available
-in the pool.
-*/
+// Get gets a Buffer from the BufferPool, or creates a new one if none are
+// available in the pool.
 func (bp *BufferPool) Get() (b *bytes.Buffer) {
 	select {
 	case b = <-bp.c:
@@ -36,9 +30,7 @@ func (bp *BufferPool) Get() (b *bytes.Buffer) {
 	return
 }
 
-/*
-Put returns the given Buffer to the BufferPool.
-*/
+// Put returns the given Buffer to the BufferPool.
 func (bp *BufferPool) Put(b *bytes.Buffer) {
 	b.Reset()
 	select {

--- a/bufferpool_test.go
+++ b/bufferpool_test.go
@@ -1,0 +1,30 @@
+package bpool
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBufferPool(t *testing.T) {
+	var size int = 4
+
+	bufPool := NewBufferPool(size)
+
+	// Test Get/Put
+	b := bufPool.Get()
+	bufPool.Put(b)
+
+	// Add some additional buffers beyond the pool size.
+	for i := 0; i < size*2; i++ {
+		bufPool.Put(bytes.NewBuffer([]byte{}))
+	}
+
+	// Close the channel so we can iterate over it.
+	close(bufPool.c)
+
+	// Check the size of the pool.
+	if len(bufPool.c) != size {
+		t.Fatalf("bufferpool size invalid: got %v want %v", len(bufPool.c), size)
+	}
+
+}

--- a/bytepool.go
+++ b/bytepool.go
@@ -1,18 +1,14 @@
 package bpool
 
-/*
-BytePool implements a leaky pool of []byte in the form of a bounded
-channel.
-*/
+// BytePool implements a leaky pool of []byte in the form of a bounded
+// channel.
 type BytePool struct {
 	c chan []byte
 	w int
 }
 
-/*
-NewBytePool creates a new BytePool bounded to the given maxSize, with new byte
-arrays sized based on width.
-*/
+// NewBytePool creates a new BytePool bounded to the given maxSize, with new
+// byte arrays sized based on width.
 func NewBytePool(maxSize int, width int) (bp *BytePool) {
 	return &BytePool{
 		c: make(chan []byte, maxSize),
@@ -20,10 +16,8 @@ func NewBytePool(maxSize int, width int) (bp *BytePool) {
 	}
 }
 
-/*
-Get gets a []byte from the BytePool, or creates a new one if none are available
-in the pool.
-*/
+// Get gets a []byte from the BytePool, or creates a new one if none are
+// available in the pool.
 func (bp *BytePool) Get() (b []byte) {
 	select {
 	case b = <-bp.c:
@@ -35,9 +29,7 @@ func (bp *BytePool) Get() (b []byte) {
 	return
 }
 
-/*
-Put returns the given Buffer to the BytePool.
-*/
+// Put returns the given Buffer to the BytePool.
 func (bp *BytePool) Put(b []byte) {
 	select {
 	case bp.c <- b:
@@ -47,9 +39,7 @@ func (bp *BytePool) Put(b []byte) {
 	}
 }
 
-/*
-Width returns the width of the byte arrays in this pool.
-*/
+// Width returns the width of the byte arrays in this pool.
 func (bp *BytePool) Width() (n int) {
 	return bp.w
 }

--- a/bytepool_test.go
+++ b/bytepool_test.go
@@ -1,0 +1,37 @@
+package bpool
+
+import "testing"
+
+func TestBytePool(t *testing.T) {
+	var size int = 4
+	var width int = 10
+
+	bufPool := NewBytePool(size, width)
+
+	// Check the width
+	if bufPool.Width() != width {
+		t.Fatalf("bytepool width invalid: got %v want %v", bufPool.Width(), width)
+	}
+
+	// Check that retrieved buffer are of the expected width
+	b := bufPool.Get()
+	if len(b) != width {
+		t.Fatalf("bytepool length invalid: got %v want %v", len(b), width)
+	}
+
+	bufPool.Put(b)
+
+	// Fill the pool beyond the capped pool size.
+	for i := 0; i < size*2; i++ {
+		bufPool.Put(make([]byte, bufPool.w))
+	}
+
+	// Close the channel so we can iterate over it.
+	close(bufPool.c)
+
+	// Check the size of the pool.
+	if len(bufPool.c) != size {
+		t.Fatalf("bytepool size invalid: got %v want %v", len(bufPool.c), size)
+	}
+
+}

--- a/sizedbufferpool.go
+++ b/sizedbufferpool.go
@@ -1,0 +1,57 @@
+package bpool
+
+import (
+	"bytes"
+)
+
+// SizedBufferPool implements a pool of bytes.Buffers in the form of a bounded
+// channel. Buffers are pre-allocated to the requested size.
+type SizedBufferPool struct {
+	c chan *bytes.Buffer
+	a int
+}
+
+// SizedBufferPool creates a new BufferPool bounded to the given size.
+// size defines the number of buffers to be retained in the pool and alloc sets
+// the initial capacity of new buffers to minimize calls to make().
+//
+// The value of alloc should seek to provide a buffer that is representative of
+// most data written to the the buffer (i.e. 95th percentile) without being
+// overly large (which will increase static memory consumption). You may wish to
+// track the capacity of your last N buffers (i.e. using an []int) prior to
+// returning them to the pool as input into calculating a suitable alloc value.
+func NewSizedBufferPool(size int, alloc int) (bp *SizedBufferPool) {
+	return &SizedBufferPool{
+		c: make(chan *bytes.Buffer, size),
+		a: alloc,
+	}
+}
+
+// Get gets a Buffer from the SizedBufferPool, or creates a new one if none are
+// available in the pool. Buffers have a pre-allocated capacity.
+func (bp *SizedBufferPool) Get() (b *bytes.Buffer) {
+	select {
+	case b = <-bp.c:
+	// reuse existing buffer
+	default:
+		// create new buffer
+		b = bytes.NewBuffer(make([]byte, 0, bp.a))
+	}
+	return
+}
+
+// Put returns the given Buffer to the SizedBufferPool.
+func (bp *SizedBufferPool) Put(b *bytes.Buffer) {
+	b.Reset()
+
+	// Release buffers over our maximum capacity and re-create a pre-sized
+	// buffer to replace it.
+	if cap(b.Bytes()) > bp.a {
+		b = bytes.NewBuffer(make([]byte, 0, bp.a))
+	}
+
+	select {
+	case bp.c <- b:
+	default: // Discard the buffer if the pool is full.
+	}
+}

--- a/sizedbufferpool.go
+++ b/sizedbufferpool.go
@@ -46,6 +46,9 @@ func (bp *SizedBufferPool) Put(b *bytes.Buffer) {
 
 	// Release buffers over our maximum capacity and re-create a pre-sized
 	// buffer to replace it.
+	// Note that the cap(b.Bytes()) provides the capacity from the read off-set
+	// only, but as we've called b.Reset() the full capacity of the underlying
+	// byte slice is returned.
 	if cap(b.Bytes()) > bp.a {
 		b = bytes.NewBuffer(make([]byte, 0, bp.a))
 	}

--- a/sizedbufferpool_test.go
+++ b/sizedbufferpool_test.go
@@ -1,0 +1,50 @@
+package bpool
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestSizedBufferPool checks that over-sized buffers are released and that new
+// buffers are created in their place.
+func TestSizedBufferPool(t *testing.T) {
+
+	var size int = 4
+	var capacity int = 1024
+
+	bufPool := NewSizedBufferPool(size, capacity)
+
+	b := bufPool.Get()
+
+	// Check the cap before we use the buffer.
+	if cap(b.Bytes()) != capacity {
+		t.Fatalf("buffer capacity incorrect: got %v want %v", cap(b.Bytes()),
+			capacity)
+	}
+
+	// Grow the buffer beyond our capacity and return it to the pool
+	b.Grow(capacity * 3)
+	bufPool.Put(b)
+
+	// Add some additional buffers to fill up the pool.
+	for i := 0; i < size; i++ {
+		bufPool.Put(bytes.NewBuffer(make([]byte, 0, bufPool.a*2)))
+	}
+
+	// Check that oversized buffers are being replaced.
+	if len(bufPool.c) < size {
+		t.Fatalf("buffer pool too small: got %v want %v", len(bufPool.c), size)
+	}
+
+	// Close the channel so we can iterate over it.
+	close(bufPool.c)
+
+	// Check that there are buffers of the correct capacity in the pool.
+	for buffer := range bufPool.c {
+		if cap(buffer.Bytes()) != bufPool.a {
+			t.Fatalf("returned buffers wrong capacity: got %v want %v",
+				cap(buffer.Bytes()), capacity)
+		}
+	}
+
+}


### PR DESCRIPTION
Added a new `bpool.SizedBufferPool` type that pre-allocates the buffers provided by the pool.

* This helps avoid cases where a buffer in a 'not-so-smart' pool might end up growing unnecessarily large due to non-typical use cases - e.g. a particularly large JSON response that's not the norm.
* The flipside is that you want to "tune" the `alloc` parameter (or at least make an educated guess) to cover your 60th+ percentile/median buffer size (etc.).
* Usage is a therefore little more obtuse than the regular `bpool.BufferPool` (changing the existing impl. would also break the API) but not hugely so.

* **Note**: I am *definitely* open to changing the name. I had `PreSizedBufferPool` and `AllocatedBufferPool` before settling on `SizedBufferPool`. None are "great" in that they are ambiguous as 'size' or 'allocated' could be conflated with the number buffers in the pool, not the allocated size of each buffer. (Grown? Measured?)

I also fleshed out the README a little further and 'standardised' the godoc comments to use `//` instead of the `/* */` syntax.